### PR TITLE
Feat: 페이지네이션 생성

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Reservation } from "@/types/types";
+import { useState } from "react";
+
+interface PaginationProps {
+  data: Reservation[]; // 데이터 배열
+  itemsPerPage?: number; // 페이지당 아이템 개수
+}
+
+const buttonStyle =
+  "flex md:h-[55px] md:w-[55px] h-[40px] w-[40px] items-center justify-center rounded-[15px] text-[18px] font-medium border border border-green02";
+
+const Pagination = ({ data, itemsPerPage = 5 }: PaginationProps) => {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(data.length / itemsPerPage); // 전체 페이지 수
+
+  // 현재 페이지 그룹 계산
+  const currentGroup = Math.ceil(currentPage / itemsPerPage);
+  const startPage = (currentGroup - 1) * itemsPerPage + 1;
+  const endPage = Math.min(startPage + itemsPerPage - 1, totalPages);
+
+  // "이전" 클릭 핸들러
+  const handlePrev = () => {
+    if (currentPage > 1) setCurrentPage(currentPage - 1);
+  };
+
+  // "다음" 클릭 핸들러
+  const handleNext = () => {
+    if (currentPage < totalPages) setCurrentPage(currentPage + 1);
+  };
+
+  // 특정 페이지 클릭 핸들러
+  const handlePageClick = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <>
+      <div className="pagination flex items-center justify-center gap-[10px]">
+        {/* 이전 버튼 */}
+        <button
+          className={`rounded bg-white ${buttonStyle} ${
+            currentPage === 1 ? "cursor-not-allowed border-gray03 opacity-50" : "hover:bg-gray02"
+          }`}
+          onClick={handlePrev}
+          disabled={currentPage === 1}
+        >
+          {"<"}
+        </button>
+
+        {/* 동적으로 페이지 번호 출력 */}
+        {Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i).map((page) => (
+          <button
+            key={page}
+            className={`${buttonStyle} ${currentPage === page ? "bg-green02 text-white" : "bg-white hover:bg-gray02"}`}
+            onClick={() => handlePageClick(page)}
+          >
+            {page}
+          </button>
+        ))}
+
+        {/* 다음 버튼 */}
+        <button
+          className={`bg-white ${buttonStyle} ${
+            currentPage === totalPages ? "cursor-not-allowed border-gray03 opacity-50" : "hover:bg-gray02"
+          }`}
+          onClick={handleNext}
+          disabled={currentPage === totalPages}
+        >
+          {">"}
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default Pagination;

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,20 +1,19 @@
 "use client";
 
-import { Reservation } from "@/types/types";
 import { useState } from "react";
 
 interface PaginationProps {
-  data: Reservation[]; // 데이터 배열
+  totalCount: number;
   itemsPerPage?: number; // 페이지당 아이템 개수
 }
 
 const buttonStyle =
   "flex md:h-[55px] md:w-[55px] h-[40px] w-[40px] items-center justify-center rounded-[15px] text-[18px] font-medium border border border-green02";
 
-const Pagination = ({ data, itemsPerPage = 5 }: PaginationProps) => {
+const Pagination = ({ totalCount, itemsPerPage = 5 }: PaginationProps) => {
   const [currentPage, setCurrentPage] = useState(1);
 
-  const totalPages = Math.ceil(data.length / itemsPerPage); // 전체 페이지 수
+  const totalPages = Math.ceil(totalCount / itemsPerPage); // 전체 페이지 수
 
   // 현재 페이지 그룹 계산
   const currentGroup = Math.ceil(currentPage / itemsPerPage);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,31 @@
+// Activity 타입 정의
+export interface Activity {
+  bannerImageUrl: string; // 배너 이미지 URL
+  title: string; // 활동 제목
+  id: number; // 활동 ID
+}
+
+// Reservation 타입 정의
+export interface Reservation {
+  id: number; // 예약 ID
+  teamId: string; // 팀 ID
+  userId: number; // 사용자 ID
+  activity: Activity; // 활동 정보
+  scheduleId: number; // 일정 ID
+  status: string; // 예약 상태
+  reviewSubmitted: boolean; // 리뷰 제출 여부
+  totalPrice: number; // 총 금액
+  headCount: number; // 참가 인원 수
+  date: string; // 예약 날짜
+  startTime: string; // 시작 시간
+  endTime: string; // 종료 시간
+  createdAt: string; // 생성 날짜
+  updatedAt: string; // 업데이트 날짜
+}
+
+// MyReservations 타입 정의
+export interface MyReservations {
+  cursorId: number; // 페이징 커서 ID
+  reservations: Reservation[]; // 예약 배열
+  totalCount: number; // 총 예약 수
+}


### PR DESCRIPTION
## 이슈 번호
#15 
우선 구현은 했지만, 페이지 만들면서 수정할 부분 수정해야할 것 같습니다. 

## 작업 내용 


- data와 itemsPerPage: data는 페이지네이션할 데이터 배열이고, itemsPerPage는 한 페이지에 표시할 아이템 수입니다(기본값 5).
- 상태 관리: currentPage 상태로 현재 페이지를 추적하고, setCurrentPage로 페이지를 변경합니다.
- 페이지 계산: 전체 페이지 수는 data.length와 itemsPerPage를 나누어 계산하고, 현재 페이지 그룹의 첫 번째 페이지와 마지막 페이지를 결정합니다.
- 핸들러: 이전 페이지, 다음 페이지, 특정 페이지로 이동하는 버튼 클릭을 처리하는 핸들러들 (handlePrev, handleNext, handlePageClick).


## 📷 이미지

![image (2)](https://github.com/user-attachments/assets/8fb3d2f9-8624-4dff-acbc-7cc0bfd73534)
