### PR TITLE
Refactor: 헤더 드롭다운에서 '마이페이지' 클릭 시 라우터 푸시 주소를 /mypage에서 /my로 변경

### DIFF
--- a/src/components/dropdown/HeaderDropdown.tsx
+++ b/src/components/dropdown/HeaderDropdown.tsx
@@ -15,7 +15,7 @@ const HeaderDropdown = ({ children }: { children: ReactNode }) => {
   const handleSelect = (value: string) => {
     setIsOpen(false);
     if (value === "mypage") {
-      router.push("/mypage");
+      router.push("/my");
     } else {
       console.log("로그아웃");
     }


### PR DESCRIPTION
## 💡이슈 번호
[ globalnomad #74 ]

## 📌 작업 내용
- 폴더 구조 변경에 따른 라우터 푸시 주소를 변경했습니다.
    - `마이페이지` 클릭 시 `/mypage` -> `/my`
