### PR TITLE
Refactor: 비밀번호 정규식에서 영문 대소문자 구분 제거

### DIFF
--- a/src/zodSchema/commonSchema.ts
+++ b/src/zodSchema/commonSchema.ts
@@ -24,7 +24,7 @@ export const NicknameSchema = z
   .regex(nicknameRegex, "닉네임은 영문, 한글, 숫자만 입력 가능하며, 특수문자와 공백은 포함할 수 없습니다.");
 
 // 개발 환경: 간소화된 비밀번호 정규 표현식 (regex)
-const simplifyPasswordRegex = /^(?=.*[a-z])(?=.*\d)[a-z\d]{8,}$/;
+const simplifyPasswordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[a-z\d]{8,}$/;
 
 // 개발 환경: 간소화된 비밀번호 스키마
 export const SimplifyPasswordSchema = z


### PR DESCRIPTION
## 💡이슈 번호
[ globalnomad #76 ]

## 📌 작업 내용
- 영문 소문자를 강제하던 기존의 비밀번호 정규식에서 영문 대소문자 구분을 제거했습니다.

    - 기존 : 영문 소문자 + 숫자
    - 수정 : 영문 + 숫자
