### PR TITLE
Feat: 토큰 재발급 기능 구현

### DIFF
--- a/src/lib/api/axiosInstanceApi.ts
+++ b/src/lib/api/axiosInstanceApi.ts
@@ -7,6 +7,13 @@ const axiosInstance = axios.create({
   },
 });
 
+export const proxy = axios.create({
+  baseURL: "http://localhost:3000",
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
 axiosInstance.interceptors.response.use(
   (res) => res, // 성공적인 응답은 그대로 반환
   async (error) => {

--- a/src/lib/api/axiosInstanceApi.ts
+++ b/src/lib/api/axiosInstanceApi.ts
@@ -7,11 +7,42 @@ const axiosInstance = axios.create({
   },
 });
 
-export const proxy = axios.create({
-  baseURL: "http://localhost:3000",
-  headers: {
-    "Content-Type": "application/json",
-  },
-});
+axiosInstance.interceptors.response.use(
+  (res) => res, // 성공적인 응답은 그대로 반환
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 401 Unauthorized 에러가 발생하고, 아직 리프레시 토큰을 시도하지 않은 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        // 토큰 갱신 요청
+        const response = await axiosInstance.post("/auth/token/refresh", undefined);
+
+        // 새로 갱신된 액세스 토큰을 쿠키에 저장
+        const newAccessToken = response.data.accessToken; // 응답에 맞게 수정 필요
+
+        // 쿠키에 토큰을 저장하는 방법
+        document.cookie = `accessToken=${newAccessToken}; path=/; Secure; HttpOnly`;
+
+        // 새 토큰을 Authorization 헤더에 설정
+        axiosInstance.defaults.headers["Authorization"] = `Bearer ${newAccessToken}`;
+
+        // 원래 요청을 새 토큰으로 재시도
+        originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        // 토큰 갱신 실패 처리
+        console.error("토큰 갱신 실패:", refreshError);
+        return Promise.reject(refreshError);
+      }
+    }
+
+    // 401 외 다른 에러는 그대로 반환
+    return Promise.reject(error);
+  }
+);
 
 export default axiosInstance;

--- a/src/lib/api/axiosInstanceApi.ts
+++ b/src/lib/api/axiosInstanceApi.ts
@@ -21,10 +21,12 @@ axiosInstance.interceptors.response.use(
         const response = await axiosInstance.post("/auth/token/refresh", undefined);
 
         // 새로 갱신된 액세스 토큰을 쿠키에 저장
-        const newAccessToken = response.data.accessToken; // 응답에 맞게 수정 필요
+        const newAccessToken = response.data.accessToken;
+        const newRefreshToken = response.data.refreshToken;
 
         // 쿠키에 토큰을 저장하는 방법
         document.cookie = `accessToken=${newAccessToken}; path=/; Secure; HttpOnly`;
+        document.cookie = `accessToken=${newRefreshToken}; path=/; Secure; HttpOnly`;
 
         // 새 토큰을 Authorization 헤더에 설정
         axiosInstance.defaults.headers["Authorization"] = `Bearer ${newAccessToken}`;


### PR DESCRIPTION
## 🔗 이슈 번호
#80 

## 작업 내용

- 401에러 시, 토큰을 재발급 받는 인터셉트 코드를 추가했습니다.
- 인터셉트에서 토큰 재발급 API 요청을 보내고 response로 accessToken과 refreshToken을 받아옵니다.
- 인터셉트는 서버에서 동작하기 때문에 이 두 토큰을 바로 쿠키에 보안 설정하여 저장할 수 있습니다. 