### PR TITLE
Feat: sidebar 및 toast css 수정

### DIFF
--- a/src/components/SideNavigation.tsx
+++ b/src/components/SideNavigation.tsx
@@ -51,7 +51,7 @@ export default function SideNavigation({ img, onClick }: SideNavigationProps) {
   // 유저데이터 바인딩
   const [user] = useState(true);
   return (
-    <div className="fixed bottom-0 z-10 flex w-screen flex-col gap-5 overflow-visible rounded-xl border border-gray03 bg-white py-3 md:relative md:h-[432px] md:w-[251px] md:min-w-[251px] md:p-6 xl:w-[384px]">
+    <div className="fixed bottom-0 z-10 flex w-screen flex-col gap-5 overflow-visible rounded-xl border border-gray03 bg-white py-3 shadow-md md:sticky md:top-10 md:h-[432px] md:w-[251px] md:min-w-[251px] md:p-6 xl:w-[384px]">
       <div className="hidden md:block">
         <div className="relative m-auto flex h-[160px] w-[160px] items-center justify-center overflow-hidden rounded-full bg-gray03">
           {user && img ? (

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -23,7 +23,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={{ success, error, info, warning }}>
       {children}
-      <ToastContainer autoClose={2000} position="bottom-right" limit={3} />
+      <ToastContainer autoClose={2000} position="top-right" stacked />
     </ToastContext.Provider>
   );
 }

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -23,7 +23,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={{ success, error, info, warning }}>
       {children}
-      <ToastContainer autoClose={2000} position="top-right" stacked />
+      <ToastContainer autoClose={2000} position="top-center" />
     </ToastContext.Provider>
   );
 }

--- a/src/components/toast/toast.css
+++ b/src/components/toast/toast.css
@@ -1,18 +1,15 @@
 .Toastify__toast {
+  width: 330px;
+  margin: 0 auto;
+  margin-top: 6px;
   border-radius: 16px;
-  color: #0b3b2d;
   font-weight: 800;
-}
-
-@media (max-width: 768px) {
-  .Toastify__toast-container--top-right {
-    top: 20px !important;
-    left: 50% !important;
-    width: 85% !important;
-    transform: translateX(-50%) !important;
-  }
 }
 
 .Toastify__close-button {
   display: none;
+}
+
+[class*="Toastify__progress-bar"] {
+  background: none !important;
 }

--- a/src/components/toast/toast.css
+++ b/src/components/toast/toast.css
@@ -1,8 +1,18 @@
 .Toastify__toast {
-  border-radius: 14px;
+  border-radius: 16px;
+  color: #0b3b2d;
+  font-weight: 800;
 }
 
-.Toastify__toast:hover {
-  transform: translateY(-4px);
-  transition: transform 0.2s ease;
+@media (max-width: 768px) {
+  .Toastify__toast-container--top-right {
+    top: 20px !important;
+    left: 50% !important;
+    width: 85% !important;
+    transform: translateX(-50%) !important;
+  }
+}
+
+.Toastify__close-button {
+  display: none;
 }


### PR DESCRIPTION
## 💡이슈 번호
[ globalnomad #90]

## 📌 작업 내용
- `SideNavigation` sticky 적용
- `Toast` 위치 이동
   - pc에서는 상단 우측
   - 모바일에서는 상단 중앙
- `Toast`  삭제 버튼 제거
- `Toast`  여러개 생성 시, 쌓이게 보이게 수정

## 📷 Preview

![11](https://github.com/user-attachments/assets/b4fc7197-176e-4bda-82e4-e816d70f0f0f)
![22](https://github.com/user-attachments/assets/ba47c88a-b1ee-4ded-a800-186d5bce0ba5)
![33](https://github.com/user-attachments/assets/68f322ff-a2ef-4f08-9f03-f256a9824eb2)



