### PR TITLE
Feat: 체험 등록 페이지 주소 검색 api 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next": "15.0.3",
         "react": "^18.2.0",
         "react-calendar": "^5.1.0",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.53.2",
         "react-icons": "^5.3.0",
@@ -5444,6 +5445,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "15.0.3",
     "react": "^18.2.0",
     "react-calendar": "^5.1.0",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.53.2",
     "react-icons": "^5.3.0",

--- a/src/app/(app)/my/activity/create/components/CreateActivityForm.tsx
+++ b/src/app/(app)/my/activity/create/components/CreateActivityForm.tsx
@@ -3,6 +3,7 @@
 import Button from "@/components/Button";
 import DropdownInput from "@/components/dropdown/DropdownInput";
 import LabelInput from "@/components/input/LabelInput";
+import PostInput from "@/components/input/PostInput";
 import Textarea from "@/components/input/Textarea";
 import { useToast } from "@/components/toast/ToastProvider";
 import { PostActivities } from "@/lib/api/Activities";
@@ -95,6 +96,7 @@ const CreateActivityForm = () => {
       <ScheduleList watch={watch} setValue={setValue} />
       <BannerImgForm watch={watch} setValue={setValue} />
       <SubImageForm watch={watch} setValue={setValue} />
+      <PostInput />
     </div>
   );
 };

--- a/src/app/(app)/my/activity/create/components/CreateActivityForm.tsx
+++ b/src/app/(app)/my/activity/create/components/CreateActivityForm.tsx
@@ -53,6 +53,7 @@ const CreateActivityForm = () => {
   };
 
   const onSubmit = async (data: PostActivityType) => {
+    console.log(data);
     data.price = Number(data.price);
     if (!data.subImageUrls || data.subImageUrls.length < 4) {
       Toast.error("소개 이미지를 4개 입력해 주세요.");
@@ -94,11 +95,10 @@ const CreateActivityForm = () => {
         }}
         type="text"
       />
-      <LabelInput label="주소" placeholder="주소를 입력해주세요" {...register("address")} />
+      <PostInput label={"주소"} watch={watch} setValue={setValue} placeholder="주소를 입력해주세요" />
       <ScheduleList watch={watch} setValue={setValue} />
       <BannerImgForm watch={watch} setValue={setValue} />
       <SubImageForm watch={watch} setValue={setValue} />
-      <PostInput />
     </div>
   );
 };

--- a/src/components/input/DateInput.tsx
+++ b/src/components/input/DateInput.tsx
@@ -10,8 +10,9 @@ interface DateInputProps {
 const DateInput = ({ onChange, value }: DateInputProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
+  // 스케줄 추가 날짜를 일주일 후 부터 설정 가능하도록 변경
+  const nextWeek = new Date();
+  nextWeek.setDate(nextWeek.getDate() + 7);
 
   const toggleDropdown = () => {
     setIsOpen((prev) => !prev);
@@ -57,7 +58,7 @@ const DateInput = ({ onChange, value }: DateInputProps) => {
           <Calendar
             onClickDay={handleDateClick}
             className="rounded-md border border-gray03"
-            minDate={tomorrow}
+            minDate={nextWeek}
             locale="en-US"
           />
         </div>

--- a/src/components/input/PostInput.tsx
+++ b/src/components/input/PostInput.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import DaumPostcodeEmbed from "react-daum-postcode";
+
+const PostInput = () => {
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [address, setAddress] = useState("");
+
+  const handleComplete = (data) => {
+    // 검색 결과에서 도로명 주소를 가져옵니다.
+    setAddress(data.address);
+    setIsPopupOpen(false); // 팝업 닫기
+  };
+
+  const togglePopup = () => {
+    setIsPopupOpen(!isPopupOpen);
+  };
+
+  return (
+    <div>
+      <button onClick={togglePopup}>{isPopupOpen ? "닫기" : "주소 검색"}</button>
+
+      {isPopupOpen && (
+        <div
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: "400px",
+            height: "500px",
+            zIndex: 100,
+            backgroundColor: "white",
+            boxShadow: "0px 4px 6px rgba(0, 0, 0, 0.1)",
+          }}
+        >
+          <DaumPostcodeEmbed onComplete={handleComplete} />
+        </div>
+      )}
+
+      <div>
+        <h3>선택한 주소:</h3>
+        <p>{address}</p>
+      </div>
+    </div>
+  );
+};
+
+export default PostInput;

--- a/src/components/input/PostInput.tsx
+++ b/src/components/input/PostInput.tsx
@@ -1,46 +1,67 @@
-import React, { useState } from "react";
-import DaumPostcodeEmbed from "react-daum-postcode";
+import { ActiviteForm } from "@/types/ActivityType";
+import React, { InputHTMLAttributes, useEffect, useState } from "react";
+import DaumPostcodeEmbed, { Address } from "react-daum-postcode";
+import { UseFormSetValue, UseFormWatch } from "react-hook-form";
+import { FiX } from "react-icons/fi";
 
-const PostInput = () => {
-  const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const [address, setAddress] = useState("");
+interface PostInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  watch: UseFormWatch<ActiviteForm>;
+  setValue: UseFormSetValue<ActiviteForm>;
+}
 
-  const handleComplete = (data) => {
-    // 검색 결과에서 도로명 주소를 가져옵니다.
-    setAddress(data.address);
-    setIsPopupOpen(false); // 팝업 닫기
+const PostInput = ({ label, watch, setValue, ...props }: PostInputProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const address = watch("address", "");
+
+  const handleComplete = (data: Address) => {
+    setValue("address", data.address);
+    setIsOpen(false);
   };
 
-  const togglePopup = () => {
-    setIsPopupOpen(!isPopupOpen);
+  const toggleModal = () => {
+    setIsOpen((prev) => !prev);
   };
+
+  // 모달 오픈 시 부모 컴포넌트 스크롤 비활성화
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "unset";
+    }
+
+    return () => {
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen]);
 
   return (
     <div>
-      <button onClick={togglePopup}>{isPopupOpen ? "닫기" : "주소 검색"}</button>
-
-      {isPopupOpen && (
-        <div
-          style={{
-            position: "absolute",
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-            width: "400px",
-            height: "500px",
-            zIndex: 100,
-            backgroundColor: "white",
-            boxShadow: "0px 4px 6px rgba(0, 0, 0, 0.1)",
-          }}
-        >
-          <DaumPostcodeEmbed onComplete={handleComplete} />
-        </div>
+      <label className="flex flex-col gap-4 text-xl font-bold leading-8 text-black03 md:text-2xl">
+        {label}
+        <input
+          className={`h-[56px] w-full rounded border border-gray08 px-5 py-4 text-base font-normal leading-[26px] outline-green02 placeholder:text-gray06`}
+          value={address}
+          readOnly
+          onClick={toggleModal}
+          {...props}
+        />
+      </label>
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 z-10 bg-black opacity-50" onClick={toggleModal} />
+          <div className="fixed left-1/2 top-1/2 z-10 flex h-dvh w-full -translate-x-1/2 -translate-y-1/2 flex-col gap-4 bg-white p-3 shadow-sm md:h-[600px] md:max-w-[500px] md:rounded md:border md:p-5">
+            <div className="flex justify-between">
+              <label className="flex flex-col gap-4 text-xl font-bold leading-8 text-black03 md:text-2xl">
+                주소 검색
+              </label>
+              <FiX className="size-6 text-black03" onClick={toggleModal} />
+            </div>
+            <DaumPostcodeEmbed theme={{ bgColor: "#ffffff" }} style={{ height: "700px" }} onComplete={handleComplete} />
+          </div>
+        </>
       )}
-
-      <div>
-        <h3>선택한 주소:</h3>
-        <p>{address}</p>
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 💡이슈 번호
[ globalnomad #87 ] 

## 📌 작업 내용
- 체험 등록 페이지 주소 입력 input 클릭 시 주소 daum 주소 검색 api 모달이 나타납니다.
- 체험 등록 시 스케줄 추가 가능한 날짜의 최솟값이 등록하는 날짜의 일주일 뒤부터 가능하도록 변경 하였습니다.


### pc, tablet
![image](https://github.com/user-attachments/assets/18ca489f-f7cc-4d65-8b50-c7c04f2960ad)

### mobile 
![image](https://github.com/user-attachments/assets/e098ceca-aca5-4eba-9fcb-428dfc037157)
