### PR TITLE
Feat: zustand로 로그인 상태 관리

### DIFF
--- a/src/app/(auth)/components/LoginForm.tsx
+++ b/src/app/(auth)/components/LoginForm.tsx
@@ -12,7 +12,7 @@ import AuthInput from "../../../components/input/AuthInput";
 
 const LoginForm = () => {
   const router = useRouter();
-  const { isLogin, setUser } = useAuthStore();
+  const { user, setUser } = useAuthStore();
   const {
     register,
     handleSubmit,
@@ -25,10 +25,10 @@ const LoginForm = () => {
 
   // 로그인 상태라면 메인 화면으로 리다이렉트
   useEffect(() => {
-    if (isLogin) {
+    if (user) {
       router.push("/");
     }
-  }, [isLogin, router]);
+  }, [user, router]);
 
   const onSubmit: SubmitHandler<Login> = async (data) => {
     try {

--- a/src/app/(auth)/components/LoginForm.tsx
+++ b/src/app/(auth)/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { postLogin } from "@/lib/api/Auth";
+import authStore from "@/store/authStore";
 import { Login, LoginSchema } from "@/zodSchema/authSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -10,6 +11,7 @@ import AuthInput from "../../../components/input/AuthInput";
 
 const LoginForm = () => {
   const router = useRouter();
+  const { setUser } = authStore();
   const {
     register,
     handleSubmit,
@@ -22,7 +24,10 @@ const LoginForm = () => {
 
   const onSubmit: SubmitHandler<Login> = async (data) => {
     try {
-      await postLogin(data); // 로그인 요청
+      const res = await postLogin(data); // 로그인 요청
+      if (res.user) {
+        setUser(res.user);
+      }
       router.push("/"); // 로그인 성공 시 로그인 페이지로 리다이렉트
     } catch (error) {
       console.error("로그인 중 오류 발생", error);

--- a/src/app/(auth)/components/LoginForm.tsx
+++ b/src/app/(auth)/components/LoginForm.tsx
@@ -5,13 +5,14 @@ import authStore from "@/store/authStore";
 import { Login, LoginSchema } from "@/zodSchema/authSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import Button from "../../../components/Button";
 import AuthInput from "../../../components/input/AuthInput";
 
 const LoginForm = () => {
   const router = useRouter();
-  const { setUser } = authStore();
+  const { isLogin, setUser } = authStore();
   const {
     register,
     handleSubmit,
@@ -21,6 +22,13 @@ const LoginForm = () => {
     resolver: zodResolver(LoginSchema),
     mode: "onChange",
   });
+
+  // 로그인 상태라면 메인 화면으로 리다이렉트
+  useEffect(() => {
+    if (isLogin) {
+      router.push("/");
+    }
+  }, [isLogin, router]);
 
   const onSubmit: SubmitHandler<Login> = async (data) => {
     try {

--- a/src/app/(auth)/components/LoginForm.tsx
+++ b/src/app/(auth)/components/LoginForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { postLogin } from "@/lib/api/Auth";
-import authStore from "@/store/authStore";
+import useAuthStore from "@/store/useAuthStore";
 import { Login, LoginSchema } from "@/zodSchema/authSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -12,7 +12,7 @@ import AuthInput from "../../../components/input/AuthInput";
 
 const LoginForm = () => {
   const router = useRouter();
-  const { isLogin, setUser } = authStore();
+  const { isLogin, setUser } = useAuthStore();
   const {
     register,
     handleSubmit,

--- a/src/app/(auth)/components/SignupForm.tsx
+++ b/src/app/(auth)/components/SignupForm.tsx
@@ -3,13 +3,16 @@
 import Button from "@/components/Button";
 import AuthInput from "@/components/input/AuthInput";
 import { postSignUp } from "@/lib/api/Users";
+import authStore from "@/store/authStore";
 import { Signup, SignupSchema } from "@/zodSchema/authSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 const SignupForm = () => {
   const router = useRouter();
+  const { isLogin } = authStore();
   const {
     register,
     handleSubmit,
@@ -19,6 +22,13 @@ const SignupForm = () => {
     resolver: zodResolver(SignupSchema),
     mode: "onChange",
   });
+
+  // 로그인 상태라면 메인 화면으로 리다이렉트
+  useEffect(() => {
+    if (isLogin) {
+      router.push("/");
+    }
+  }, [isLogin, router]);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit: SubmitHandler<Signup> = async ({ confirmPassword, ...submitData }) => {

--- a/src/app/(auth)/components/SignupForm.tsx
+++ b/src/app/(auth)/components/SignupForm.tsx
@@ -12,7 +12,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 
 const SignupForm = () => {
   const router = useRouter();
-  const { isLogin } = useAuthStore();
+  const { user } = useAuthStore();
   const {
     register,
     handleSubmit,
@@ -25,10 +25,10 @@ const SignupForm = () => {
 
   // 로그인 상태라면 메인 화면으로 리다이렉트
   useEffect(() => {
-    if (isLogin) {
+    if (user) {
       router.push("/");
     }
-  }, [isLogin, router]);
+  }, [user, router]);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit: SubmitHandler<Signup> = async ({ confirmPassword, ...submitData }) => {

--- a/src/app/(auth)/components/SignupForm.tsx
+++ b/src/app/(auth)/components/SignupForm.tsx
@@ -3,7 +3,7 @@
 import Button from "@/components/Button";
 import AuthInput from "@/components/input/AuthInput";
 import { postSignUp } from "@/lib/api/Users";
-import authStore from "@/store/authStore";
+import useAuthStore from "@/store/useAuthStore";
 import { Signup, SignupSchema } from "@/zodSchema/authSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -12,7 +12,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 
 const SignupForm = () => {
   const router = useRouter();
-  const { isLogin } = authStore();
+  const { isLogin } = useAuthStore();
   const {
     register,
     handleSubmit,

--- a/src/app/(auth)/components/SocialLogin.tsx
+++ b/src/app/(auth)/components/SocialLogin.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 const SocialLogin = () => {
   return (
     <div className="relative mt-7 w-full border-t border-gray03 md:mt-10">
-      <p className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap bg-white px-[23.5px] text-gray08 md:-top-4 md:px-[37.5px] md:text-xl md:leading-8">
+      <p className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap bg-gray01 px-[23.5px] text-gray08 md:-top-4 md:px-[37.5px] md:text-xl md:leading-8">
         SNS 계정으로 로그인하기
       </p>
       <div className="mx-auto flex w-fit gap-4 pt-9 md:pt-14">

--- a/src/app/(auth)/components/SocialSignup.tsx
+++ b/src/app/(auth)/components/SocialSignup.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 const SocialSignup = () => {
   return (
     <div className="relative mt-7 w-full border-t border-gray03 md:mt-10">
-      <p className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap bg-white px-[23.5px] text-gray08 md:-top-4 md:px-[37.5px] md:text-xl md:leading-8">
+      <p className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap bg-gray01 px-[23.5px] text-gray08 md:-top-4 md:px-[37.5px] md:text-xl md:leading-8">
         SNS 계정으로 회원가입하기
       </p>
       <div className="mx-auto flex w-fit gap-4 pt-9 md:pt-14">

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -15,7 +15,7 @@ export const POST = async (req: NextRequest) => {
 
     if (accessToken && refreshToken) {
       // accessToken을 쿠키에 저장
-      const res = NextResponse.json({ message: "로그인 성공" }, { status: 200 });
+      const res = NextResponse.json({ message: "로그인 성공", user: response.data.user }, { status: 200 });
 
       res.cookies.set("accessToken", accessToken, {
         httpOnly: true,

--- a/src/components/dropdown/HeaderDropdown.tsx
+++ b/src/components/dropdown/HeaderDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import authStore from "@/store/authStore";
 import { useRouter } from "next/navigation";
 import { ReactNode, useEffect, useRef, useState } from "react";
 
@@ -7,6 +8,7 @@ const HeaderDropdown = ({ children }: { children: ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
+  const { clearUser } = authStore();
 
   const toggleDropdown = () => {
     setIsOpen((prev) => !prev);
@@ -17,7 +19,7 @@ const HeaderDropdown = ({ children }: { children: ReactNode }) => {
     if (value === "mypage") {
       router.push("/my");
     } else {
-      console.log("로그아웃");
+      clearUser();
     }
   };
 

--- a/src/components/dropdown/HeaderDropdown.tsx
+++ b/src/components/dropdown/HeaderDropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import authStore from "@/store/authStore";
+import useAuthStore from "@/store/useAuthStore";
 import { useRouter } from "next/navigation";
 import { ReactNode, useEffect, useRef, useState } from "react";
 
@@ -8,7 +8,7 @@ const HeaderDropdown = ({ children }: { children: ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
-  const { clearUser } = authStore();
+  const { clearUser } = useAuthStore();
 
   const toggleDropdown = () => {
     setIsOpen((prev) => !prev);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import authStore from "@/store/authStore";
+import useAuthStore from "@/store/useAuthStore";
 import Image from "next/image";
 import Link from "next/link";
 import { IoPersonCircleOutline } from "react-icons/io5";
@@ -8,7 +8,7 @@ import HeaderDropdown from "../dropdown/HeaderDropdown";
 import Notification from "./Notification";
 
 const Header = () => {
-  const { user } = authStore();
+  const { user } = useAuthStore();
 
   return (
     <div className="h-[70px] w-full border-b border-gray03 p-5">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,6 @@
-import { User } from "@/types/types";
+"use client";
+
+import authStore from "@/store/authStore";
 import Image from "next/image";
 import Link from "next/link";
 import { IoPersonCircleOutline } from "react-icons/io5";
@@ -6,15 +8,7 @@ import HeaderDropdown from "../dropdown/HeaderDropdown";
 import Notification from "./Notification";
 
 const Header = () => {
-  const user: User = {
-    id: 1279,
-    email: "sprint91@codeit.kr",
-    nickname: "나나문",
-    profileImageUrl:
-      "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/profile_image/9-1_1279_1732338379593.jpeg",
-    createdAt: "2024-11-18T19:46:59.369Z",
-    updatedAt: "2024-11-23T14:19:30.749Z",
-  };
+  const { user } = authStore();
 
   return (
     <div className="h-[70px] w-full border-b border-gray03 p-5">

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,26 @@
+import { User } from "@/types/types";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AuthStore {
+  user: User | null;
+  isLogin: boolean;
+  setUser: (userData: User) => void;
+  clearUser: () => void;
+}
+
+const authStore = create(
+  persist<AuthStore>(
+    (set) => ({
+      user: null,
+      isLogin: false,
+      setUser: (userData) => set({ user: userData, isLogin: true }),
+      clearUser: () => set({ user: null, isLogin: false }),
+    }),
+    {
+      name: "auth-storage",
+    }
+  )
+);
+
+export default authStore;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -9,7 +9,7 @@ interface AuthStore {
   clearUser: () => void;
 }
 
-const authStore = create(
+const useAuthStore = create(
   persist<AuthStore>(
     (set) => ({
       user: null,
@@ -23,4 +23,4 @@ const authStore = create(
   )
 );
 
-export default authStore;
+export default useAuthStore;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -4,7 +4,6 @@ import { persist } from "zustand/middleware";
 
 interface AuthStore {
   user: User | null;
-  isLogin: boolean;
   setUser: (userData: User) => void;
   clearUser: () => void;
 }
@@ -13,9 +12,8 @@ const useAuthStore = create(
   persist<AuthStore>(
     (set) => ({
       user: null,
-      isLogin: false,
-      setUser: (userData) => set({ user: userData, isLogin: true }),
-      clearUser: () => set({ user: null, isLogin: false }),
+      setUser: (userData) => set({ user: userData }),
+      clearUser: () => set({ user: null }),
     }),
     {
       name: "auth-storage",


### PR DESCRIPTION
## 🔗이슈 번호
[ globalnomad #101 ]

## 📌 작업 내용
- 로그인 시 유저 정보를 zustand에 저장하여 관리하도록 구현했습니다.
- Header 컴포넌트에서 mockdata 대신 zustand의 user 데이터를 가져와 사용하도록 수정했습니다.
- 새로고침해도 로그인 상태가 유지되도록 persist 설정을 추가했습니다.

> 😡 로그인 상태에서 새로고침 시 잠깐 로그인이 풀린 것처럼 보이는 현상이 있습니다.

## 📷 Preview

https://github.com/user-attachments/assets/32af71e7-b4e7-49cb-828b-bc7908b795ad







