### PR TITLE
Fix: 체험 상세 페이지 디자인 수정

### DIFF
--- a/src/app/(app)/activities/[activityId]/components/ActivityCalendar.tsx
+++ b/src/app/(app)/activities/[activityId]/components/ActivityCalendar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import useActivityStore from "@/store/useActivityStore";
 import "@/styles/ActivityCalender.css";
 import { Schedule } from "@/types/types";
 import { formatToLocalDateString, isDateAvailable } from "@/utils/calendarUtils";
@@ -24,7 +25,7 @@ const TimeSlot = ({ time, isSelected, onClick }: { time: string; isSelected: boo
 
 const ActivityCalendar = ({ schedules, onChange }: ActivityCalendarProps) => {
   const [timeList, setTimeList] = useState<string[]>([]);
-  const [selectedTime, setSelectedTime] = useState<string>("null");
+  const { selectedTime, setSelectedTime } = useActivityStore();
 
   const handleDateClick = (date: Date): void => {
     const localFormattedDate = formatToLocalDateString(date);

--- a/src/app/(app)/activities/[activityId]/components/Banner.tsx
+++ b/src/app/(app)/activities/[activityId]/components/Banner.tsx
@@ -66,15 +66,15 @@ const Banner = ({ id }: { id: number }) => {
       {deviceType === "mobile" ? (
         <Carousel images={images} />
       ) : (
-        <div className="flex w-full justify-center gap-1 md:rounded-xl xl:gap-2">
+        <div className="relative flex h-full w-full justify-center gap-1 md:rounded-xl xl:gap-2">
           <Image
             src={bannerImageUrl}
             alt="배너 이미지"
             width={375}
             height={310}
-            className="h-full w-full object-cover md:max-h-[534px] md:rounded-l-xl"
+            className="w-full object-cover md:max-h-[534px] md:rounded-l-xl"
           />
-          <div className="h-full w-full rounded-r-xl sm:max-h-[310px] md:grid md:max-h-[534px] md:grid-cols-2 md:grid-rows-2 md:gap-1 xl:gap-2">
+          <div className="h-full w-full overflow-hidden rounded-r-xl sm:max-h-[310px] md:grid md:max-h-[534px] md:grid-cols-2 md:grid-rows-2 md:gap-1 xl:gap-2">
             {subImages.map((item) => (
               <Image
                 src={item.imageUrl}
@@ -82,7 +82,7 @@ const Banner = ({ id }: { id: number }) => {
                 width={375}
                 height={310}
                 key={item.id}
-                className="h-full w-full overflow-hidden object-cover md:max-h-[263px]"
+                className="h-full w-full object-cover md:max-h-[263px]"
               />
             ))}
           </div>

--- a/src/app/(app)/activities/[activityId]/components/MainContent.tsx
+++ b/src/app/(app)/activities/[activityId]/components/MainContent.tsx
@@ -34,17 +34,15 @@ const MainContent = ({ id }: { id: number }) => {
   const { description, address } = activityDetailData;
 
   return (
-    <div>
-      <div className="w-full px-4 md:border-t md:border-t-gray08 md:p-6 xl:max-w-[790px] xl:p-0">
-        <div className="border-b border-b-gray08 pb-4 md:pb-10 xl:pb-[34px] xl:pt-10">
-          <h3 className="mb-4 text-[20px] font-bold text-black02">체험 설명</h3>
-          <p className="text-[16px] text-gray08">{description}</p>
-        </div>
-        <div className="z-0 pt-4 md:border-b md:border-b-gray08 md:py-10">
-          <KakaoMap address={address} />
-        </div>
-        <CommentList activityId={id} />
+    <div className="w-full px-4 md:border-t md:border-t-gray08 md:p-6 xl:min-w-[790px] xl:p-0">
+      <div className="border-b border-b-gray08 pb-4 md:pb-10 xl:pb-[34px] xl:pt-10">
+        <h3 className="mb-4 text-[20px] font-bold text-black02">체험 설명</h3>
+        <p className="text-[16px] text-gray08">{description}</p>
       </div>
+      <div className="z-0 pt-4 md:border-b md:border-b-gray08 md:py-10">
+        <KakaoMap address={address} />
+      </div>
+      <CommentList activityId={id} />
     </div>
   );
 };

--- a/src/app/(app)/activities/[activityId]/components/SideBar.tsx
+++ b/src/app/(app)/activities/[activityId]/components/SideBar.tsx
@@ -64,7 +64,7 @@ const SideBar = ({ id }: { id: number }) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selectedId, setSelectedId] = useState<number | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const { success, warning } = useToast();
+  const Toast = useToast();
   const { setSelectedTime } = useActivityStore();
 
   const {
@@ -93,14 +93,14 @@ const SideBar = ({ id }: { id: number }) => {
       setIsLoading(true);
       if (!selectedId) return;
       await postReservation({ activityId: id, scheduleId: selectedId, headCount: partyNum });
-      success("예약 성공하셨습니다!");
+      Toast.success("예약 성공하셨습니다!");
       setPartyNum(0);
       setSelectedId(undefined);
       setSelectedTime("");
     } catch (error) {
       if (isAxiosError(error)) {
         const errorMessage = error.response?.data?.message || "서버 오류";
-        warning(errorMessage);
+        Toast.error(errorMessage);
       }
     } finally {
       setIsLoading(false);

--- a/src/app/(app)/activities/[activityId]/components/SideBar.tsx
+++ b/src/app/(app)/activities/[activityId]/components/SideBar.tsx
@@ -4,6 +4,7 @@ import { useToast } from "@/components/toast/ToastProvider";
 import useDeviceType from "@/hooks/useDeviceType";
 import { getActivityDetail, postReservation } from "@/lib/api/Activities";
 import SideBarSkeleton from "@/skeleton/activities/SideBarSkeleton";
+import useActivityStore from "@/store/useActivityStore";
 import { Schedule } from "@/types/types";
 import formatPrice from "@/utils/formatPrice";
 import { useQuery } from "@tanstack/react-query";
@@ -64,6 +65,7 @@ const SideBar = ({ id }: { id: number }) => {
   const [selectedId, setSelectedId] = useState<number | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { success, warning } = useToast();
+  const { setSelectedTime } = useActivityStore();
 
   const {
     data: activityDetailData,
@@ -94,6 +96,7 @@ const SideBar = ({ id }: { id: number }) => {
       success("예약 성공하셨습니다!");
       setPartyNum(0);
       setSelectedId(undefined);
+      setSelectedTime("");
     } catch (error) {
       if (isAxiosError(error)) {
         const errorMessage = error.response?.data?.message || "서버 오류";

--- a/src/app/(app)/activities/[activityId]/components/SideBar.tsx
+++ b/src/app/(app)/activities/[activityId]/components/SideBar.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useToast } from "@/components/toast/ToastProvider";
 import useDeviceType from "@/hooks/useDeviceType";
 import { getActivityDetail, postReservation } from "@/lib/api/Activities";
 import SideBarSkeleton from "@/skeleton/activities/SideBarSkeleton";
 import { Schedule } from "@/types/types";
 import formatPrice from "@/utils/formatPrice";
 import { useQuery } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import React, { useState } from "react";
@@ -61,6 +63,7 @@ const SideBar = ({ id }: { id: number }) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selectedId, setSelectedId] = useState<number | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const { success, warning } = useToast();
 
   const {
     data: activityDetailData,
@@ -88,8 +91,14 @@ const SideBar = ({ id }: { id: number }) => {
       setIsLoading(true);
       if (!selectedId) return;
       await postReservation({ activityId: id, scheduleId: selectedId, headCount: partyNum });
+      success("예약 성공하셨습니다!");
+      setPartyNum(0);
+      setSelectedId(undefined);
     } catch (error) {
-      console.error(error);
+      if (isAxiosError(error)) {
+        const errorMessage = error.response?.data?.message || "서버 오류";
+        warning(errorMessage);
+      }
     } finally {
       setIsLoading(false);
     }
@@ -129,8 +138,8 @@ const SideBar = ({ id }: { id: number }) => {
           <PartyNumberSelector partyNum={partyNum} setPartyNum={setPartyNum} />
           <button
             onClick={handleSubmit}
-            className="h-[56px] w-full rounded bg-black02 text-[16px] font-bold text-white md:mt-8 xl:mt-6"
-            disabled={isLoading}
+            className="h-[56px] w-full rounded bg-black02 text-[16px] font-bold text-white disabled:opacity-80 md:mt-8 xl:mt-6"
+            disabled={isLoading || partyNum === 0 || selectedId === undefined}
           >
             예약하기
           </button>

--- a/src/app/(app)/activities/[activityId]/page.tsx
+++ b/src/app/(app)/activities/[activityId]/page.tsx
@@ -9,8 +9,10 @@ const ActivityDetailPage = async ({ params }: { params: Promise<{ activityId: st
   return (
     <div>
       <Banner id={Number(activityId)} />
-      <div className="relative flex pb-48 xl:gap-6">
-        <MainContent id={Number(activityId)} />
+      <div className="relative flex justify-between pb-48 xl:gap-6">
+        <div className="flex-1">
+          <MainContent id={Number(activityId)} />
+        </div>
         <SideBar id={Number(activityId)} />
       </div>
     </div>

--- a/src/lib/api/Activities.ts
+++ b/src/lib/api/Activities.ts
@@ -27,7 +27,9 @@ export const postReservation = async ({
     const response = await proxy.post(`/api/activities/reservations`, { activityId, scheduleId, headCount });
     return response.data;
   } catch (error) {
-    console.error("체험 예약 신청 오류: ", error);
+    if (isAxiosError(error)) {
+      throw error;
+    }
   }
 };
 

--- a/src/store/useActivityStore.ts
+++ b/src/store/useActivityStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface ActivityState {
+  selectedTime: string;
+  setSelectedTime: (time: string) => void;
+}
+
+const useActivityStore = create<ActivityState>((set) => ({
+  selectedTime: "",
+  setSelectedTime: (time: string) => set({ selectedTime: time }),
+}));
+
+export default useActivityStore;


### PR DESCRIPTION
## 이슈 번호

#105 

## 작업 내용

- 배너 이미지의 비율이 깨지는 부분을 해결했습니다.
- 메인 컨텐츠의 가로 길이가 어긋나는 것을 해결했습니다.
- toast를 통해 api요청에 대한 액션을 추가했습니다.
- useActivityStore를 생성했습니다. 

## 이미지

![screencapture-localhost-3000-activities-3360-2024-12-10-16_24_01](https://github.com/user-attachments/assets/8e004cda-717c-48b2-95fc-5e462ae058cd)

