### PR TITLE
Feat: 예약 내역 Proxy 연결

### DIFF
--- a/src/app/api/my/reservation/route.ts
+++ b/src/app/api/my/reservation/route.ts
@@ -1,0 +1,57 @@
+import axiosInstance from "@/lib/api/axiosInstanceApi";
+import { isAxiosError } from "axios";
+import { NextRequest, NextResponse } from "next/server";
+
+// 내 예약 요청
+export const GET = async (req: NextRequest) => {
+  const accessToken = req.cookies.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: "로그인이 필요합니다" }, { status: 401 });
+  }
+
+  try {
+    const response = await axiosInstance.get("/my-reservations", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      params: {
+        size: 20,
+      },
+    });
+    return NextResponse.json(response.data, { status: 200 });
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const errorMessage = error.response?.data?.message || "서버 오류";
+      return NextResponse.json({ message: errorMessage }, { status: error.response?.status || 500 });
+    }
+    console.error(error);
+    return NextResponse.json({ message: "서버 오류" }, { status: 500 });
+  }
+};
+
+// 내 예약 취소 요청
+export const PATCH = async (req: NextRequest) => {
+  const accessToken = req.cookies.get("accessToken")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: "로그인이 필요합니다" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const response = await axiosInstance.patch(`/my-reservations/${body.reservationId}`, body, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return NextResponse.json(response.data, { status: 200 });
+  } catch (error: unknown) {
+    if (isAxiosError(error)) {
+      const errorMessage = error.response?.data?.message || "서버 오류";
+      return NextResponse.json({ message: errorMessage }, { status: error.response?.status || 500 });
+    }
+    console.error(error);
+    return NextResponse.json({ message: "서버 오류" }, { status: 500 });
+  }
+};

--- a/src/lib/api/MyReservation.ts
+++ b/src/lib/api/MyReservation.ts
@@ -1,29 +1,37 @@
-import { Reservation, ReservationResponse } from "@/types/MyReservationType";
-import axios, { AxiosError } from "axios";
+import { isAxiosError } from "axios";
 import { proxy } from "./axiosInstanceApi";
 
-export const getMyReservation = async (): Promise<Reservation[]> => {
+// 내 예약 정보 요청
+export const getMyReservation = async () => {
   try {
-    const { data } = await proxy.get<ReservationResponse>("api/my-reservations", {
-      params: { size: 10 },
-    });
-    return data.reservations;
+    const response = await proxy.get("api/my/reservation");
+    return response.data.reservations;
   } catch (error) {
-    if (axios.isAxiosError(error)) {
-      throw new Error(error.response?.data?.message || "예약 정보를 가져오는데 실패했습니다.");
+    if (isAxiosError(error)) {
+      const message = error.response?.data?.message || "서버 오류가 발생했습니다.";
+      throw new Error(message);
     }
-    throw error;
+
+    // Axios 외의 예외 처리
+    throw new Error("알 수 없는 오류가 발생했습니다.");
   }
 };
 
-export const cancelMyReservation = async (reservationId: number): Promise<void> => {
+// 내 예약 취소 요청
+export const cancelMyReservation = async (reservationId: number) => {
   try {
-    const { data } = await proxy.patch(`api/my-reservations/${reservationId}`, { status: "canceled" });
-    return data;
+    const response = await proxy.patch("api/my/reservation", {
+      reservationId,
+      status: "canceled",
+    });
+    return response.data;
   } catch (error) {
-    if (error instanceof AxiosError) {
-      throw new Error(error.response?.data?.message || "예약 삭제에 실패했습니다.");
+    if (isAxiosError(error)) {
+      const message = error.response?.data?.message || "서버 오류가 발생했습니다.";
+      throw new Error(message);
     }
-    throw error;
+
+    // Axios 외의 예외 처리
+    throw new Error("알 수 없는 오류가 발생했습니다.");
   }
 };

--- a/src/lib/api/MyReservation.ts
+++ b/src/lib/api/MyReservation.ts
@@ -4,7 +4,7 @@ import { proxy } from "./axiosInstanceApi";
 // 내 예약 정보 요청
 export const getMyReservation = async () => {
   try {
-    const response = await proxy.get("api/my/reservation");
+    const response = await proxy.get("/api/my/reservation");
     return response.data.reservations;
   } catch (error) {
     if (isAxiosError(error)) {
@@ -20,7 +20,7 @@ export const getMyReservation = async () => {
 // 내 예약 취소 요청
 export const cancelMyReservation = async (reservationId: number) => {
   try {
-    const response = await proxy.patch("api/my/reservation", {
+    const response = await proxy.patch("/api/my/reservation", {
       reservationId,
       status: "canceled",
     });


### PR DESCRIPTION
💡이슈 번호
[ globalnomad #56]

📌 작업 내용
- 예약내역 페이지 내 데이터 연결 작업했습니다
   - 유저의 예약 상황에 따라 데이터가 렌더링됩니다
   - `pending` 상태의 경우, 예약 취소 버튼이 hover로 보입니다
   - 예약 취소 로직 구현했습니다

📙 추가 필요사항
스켈레톤 ui 구현
